### PR TITLE
Better link deserialization; don't deserialize local images from HTML

### DIFF
--- a/src/editor/plugins/Image/extensions.js
+++ b/src/editor/plugins/Image/extensions.js
@@ -65,7 +65,7 @@ export const deserializeImageTag = (editor, el) => {
 
   // TODO: recognize more unsupported protocols
   if (attrs.src.startsWith('file:///')) {
-    return [jsx('text', {}, '')];
+    return null;
   }
 
   return [jsx('element', attrs, [{ text: '' }])];

--- a/src/editor/plugins/Image/extensions.js
+++ b/src/editor/plugins/Image/extensions.js
@@ -58,9 +58,16 @@ export const insertImage = (editor, url, { typeImg = IMAGE } = {}) => {
 export const deserializeImageTag = (editor, el) => {
   const attrs = { type: IMAGE };
 
+  // TODO: not all of these attributes should be stored in the DB
   for (const name of el.getAttributeNames()) {
     attrs[name] = el.getAttribute(name);
   }
+
+  // TODO: recognize more unsupported protocols
+  if (attrs.src.startsWith('file:///')) {
+    return [jsx('text', {}, '')];
+  }
+
   return [jsx('element', attrs, [{ text: '' }])];
 };
 

--- a/src/editor/plugins/Link/deserialize.js
+++ b/src/editor/plugins/Link/deserialize.js
@@ -4,6 +4,16 @@ import { deserialize } from 'volto-slate/editor/deserialize';
 // import { Editor } from 'slate';
 
 /**
+ * @param {HTMLAnchorElement} aEl
+ */
+const hasValidTarget = (aEl) => {
+  return (
+    aEl.hasAttribute('target') &&
+    ['_blank', '_self', '_parent', '_top'].includes(aEl.getAttribute('target'))
+  );
+};
+
+/**
  * This is almost the inverse function of LinkElement render function at
  * src/editor/plugins/Link/render.jsx
  * @param {Editor} editor
@@ -24,13 +34,12 @@ export const linkDeserializer = (editor, el) => {
 
   if (el.hasAttribute('title')) attrs.data.title = el.getAttribute('title');
 
+  const targetSet = hasValidTarget(el);
+
   // We don't use this isExternalLink because links can come w/o a target from
   // outside of Volto Slate blocks and still be external.
   // let isExternalLink;
-  if (
-    el.hasAttribute('target') &&
-    ['_blank', '_self', '_parent', '_top'].includes(el.getAttribute('target'))
-  ) {
+  if (targetSet) {
     attrs.data = attrs.data || {};
     attrs.data.link = attrs.data.link || {};
     attrs.data.link.external = { target: el.getAttribute('target') };
@@ -64,6 +73,9 @@ export const linkDeserializer = (editor, el) => {
     attrs.data.link = attrs.data.link || {};
     attrs.data.link.external = attrs.data.link.external || {};
     attrs.data.link.external.external_link = attrs.url;
+    if (!targetSet) {
+      attrs.data.link.external.target = '_self';
+    }
   }
 
   return jsx('element', attrs, children);

--- a/src/editor/plugins/Link/deserialize.js
+++ b/src/editor/plugins/Link/deserialize.js
@@ -27,7 +27,10 @@ export const linkDeserializer = (editor, el) => {
   // We don't use this isExternalLink because links can come w/o a target from
   // outside of Volto Slate blocks and still be external.
   // let isExternalLink;
-  if (el.hasAttribute('target')) {
+  if (
+    el.hasAttribute('target') &&
+    ['_blank', '_self', '_parent', '_top'].includes(el.getAttribute('target'))
+  ) {
     attrs.data = attrs.data || {};
     attrs.data.link = attrs.data.link || {};
     attrs.data.link.external = { target: el.getAttribute('target') };

--- a/src/editor/plugins/Link/schema.js
+++ b/src/editor/plugins/Link/schema.js
@@ -80,7 +80,7 @@ export const ExternalLinkSchema = {
     target: {
       title: 'Target',
       choices: [
-        ['', 'Open in this window / frame'],
+        ['_self', 'Open in this window / frame'],
         ['_blank', 'Open in new window'],
         ['_parent', 'Open in parent window / frame'],
         ['_top', 'Open in top frame (replaces all frames)'],


### PR DESCRIPTION
1. don't deserialize `file:///` images from HTML context
2. add a few `TODO` comments
3. use `_self` instead of empty string for the link plugin's sidebar