### PR TITLE
Improve StyleMenu interactivity

### DIFF
--- a/src/editor/plugins/StyleMenu/StyleMenu.jsx
+++ b/src/editor/plugins/StyleMenu/StyleMenu.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useSlate } from 'slate-react';
 import { Editor } from 'slate';
 import Select, { components } from 'react-select';
@@ -120,6 +120,7 @@ const selectStyles = {
 const StylingsButton = (props) => {
   const editor = useSlate();
   const intl = useIntl();
+  const [open, setOpen] = useState(false);
 
   // Converting the settings to a format that is required by react-select.
   const rawOpts = [
@@ -164,6 +165,10 @@ const StylingsButton = (props) => {
     <Select
       options={opts}
       value={toSelect}
+      menuIsOpen={open}
+      onBlur={() => {
+        setOpen(false);
+      }}
       isMulti={true}
       styles={selectStyles}
       placeholder="No Style"
@@ -173,6 +178,8 @@ const StylingsButton = (props) => {
       }
       components={{
         // Shows the most relevant part of the selection as a simple string of text.
+        // TODO: show all the styles selected with commas between them and
+        // ellipsis just at the end of the MultiValue right side limit
         MultiValue: (props) => {
           const val = props.getValue();
 
@@ -184,6 +191,43 @@ const StylingsButton = (props) => {
           }
 
           return '';
+        },
+        Control: (props) => {
+          const {
+            children,
+            cx,
+            getStyles,
+            className,
+            isDisabled,
+            isFocused,
+            innerRef,
+            innerProps,
+            menuIsOpen,
+          } = props;
+          return (
+            <div
+              ref={innerRef}
+              role="presentation"
+              style={getStyles('control', props)}
+              className={cx(
+                {
+                  control: true,
+                  'control--is-disabled': isDisabled,
+                  'control--is-focused': isFocused,
+                  'control--menu-is-open': menuIsOpen,
+                },
+                className,
+              )}
+              {...innerProps}
+              // The only difference from the initial React-Select's Control
+              // component:
+              onClick={() => {
+                setOpen(!open);
+              }}
+            >
+              {children}
+            </div>
+          );
         },
       }}
       theme={(theme) => {


### PR DESCRIPTION
It is easier to open the styles menu and it stays open until blur so the user can select multiple styles for the same selection.

 *Before:* it was opening just on click on the down arrow sign, now it works with the placeholder and the multi-value display, in its full width.