### PR TITLE
Basic keyboard shortcuts work

### DIFF
--- a/src/blocks/Text/ShortcutListing.jsx
+++ b/src/blocks/Text/ShortcutListing.jsx
@@ -12,11 +12,11 @@ const ShortcutListing = (props) => {
 
       <Segment secondary attached>
         <List>
-          {Object.entries(hotkeys || {}).map(([shortcut, format]) => (
+          {Object.entries(hotkeys || {}).map(([shortcut, { format, type }]) => (
             <List.Item key={shortcut}>{`${shortcut}: ${format}`}</List.Item>
           ))}
         </List>
-        <div>On Windows, the MOD key is Ctrl, on MacOSX it's Cmd.</div>
+        <div>On Windows, the MOD key is Ctrl, on Mac OS X it's Cmd.</div>
       </Segment>
     </div>
   );

--- a/src/editor/SlateEditor.jsx
+++ b/src/editor/SlateEditor.jsx
@@ -226,7 +226,7 @@ class SlateEditor extends Component {
                     if (type === 'inline') {
                       toggleInlineFormat(editor, format);
                     } else {
-                      // type === 'mark
+                      // type === 'mark'
                       toggleMark(editor, format);
                     }
 

--- a/src/editor/SlateEditor.jsx
+++ b/src/editor/SlateEditor.jsx
@@ -11,11 +11,14 @@ import { SlateToolbar, SlateContextToolbar } from './ui';
 import { settings } from '~/config';
 
 import withTestingFeatures from './extensions/withTestingFeatures';
-import { hasRangeSelection } from 'volto-slate/utils'; // fixSelection,
+import {
+  hasRangeSelection,
+  toggleInlineFormat,
+  toggleMark,
+} from 'volto-slate/utils'; // fixSelection,
 import EditorContext from './EditorContext';
 
 import isHotkey from 'is-hotkey';
-import { toggleMark } from 'volto-slate/utils';
 
 import './less/editor.less';
 
@@ -215,11 +218,18 @@ class SlateEditor extends Component {
               onKeyDown={(event) => {
                 let wasHotkey = false;
 
-                for (const hotkey in slate.hotkeys) {
-                  if (isHotkey(hotkey, event)) {
+                for (const hk of Object.entries(slate.hotkeys)) {
+                  const [shortcut, { format, type }] = hk;
+                  if (isHotkey(shortcut, event)) {
                     event.preventDefault();
-                    const mark = slate.hotkeys[hotkey];
-                    toggleMark(editor, mark);
+
+                    if (type === 'inline') {
+                      toggleInlineFormat(editor, format);
+                    } else {
+                      // type === 'mark
+                      toggleMark(editor, format);
+                    }
+
                     wasHotkey = true;
                   }
                 }

--- a/src/editor/config.jsx
+++ b/src/editor/config.jsx
@@ -41,7 +41,12 @@ import {
 // Registry of available buttons
 export const buttons = {
   bold: (props) => (
-    <MarkElementButton title="Bold" format="b" icon={boldIcon} {...props} />
+    <MarkElementButton
+      title="Bold"
+      format="strong"
+      icon={boldIcon}
+      {...props}
+    />
   ),
   italic: (props) => (
     <MarkElementButton
@@ -167,10 +172,10 @@ export const extensions = [
 
 // Default hotkeys and the format they trigger
 export const hotkeys = {
-  'mod+b': 'bold',
-  'mod+i': 'italic',
-  'mod+u': 'underline',
-  'mod+`': 'code',
+  'mod+b': { format: 'strong', type: 'inline' },
+  'mod+i': { format: 'em', type: 'inline' },
+  'mod+u': { format: 'u', type: 'inline' },
+  'mod+`': { format: 'code', type: 'inline' },
   // TODO: more hotkeys, including from plugins!
 };
 

--- a/src/editor/config.jsx
+++ b/src/editor/config.jsx
@@ -175,7 +175,7 @@ export const hotkeys = {
   'mod+b': { format: 'strong', type: 'inline' },
   'mod+i': { format: 'em', type: 'inline' },
   'mod+u': { format: 'u', type: 'inline' },
-  'mod+`': { format: 'code', type: 'inline' },
+  // 'mod+`': { format: 'code', type: 'inline' },
   // TODO: more hotkeys, including from plugins!
 };
 


### PR DESCRIPTION
`Ctrl + I`, `Ctrl + U`, `Ctrl + B` work even when there is no expanded selection by changing the entire paragraph or list item.