### PR TITLE
Solve issue: cursor not moving on Paste in empty Slate Text block

### DIFF
--- a/src/editor/extensions/insertData.js
+++ b/src/editor/extensions/insertData.js
@@ -60,7 +60,7 @@ export const insertData = (editor) => {
     console.log('fragment', fragment);
     const nodes = normalizeBlockNodes(editor, fragment);
     console.log('insert nodes', nodes);
-    Transforms.insertNodes(editor, nodes);
+    Transforms.insertFragment(editor, nodes);
 
     // TODO: This used to solve a problem when pasting images. What is it?
     // Transforms.deselect(editor);


### PR DESCRIPTION
`Transforms.insertNodes` does not change selection, so I used `Transforms.insertFragment`.