### PR TITLE
Make selection in Slate Text blocks work well with keyboard again

### DIFF
--- a/src/blocks/Text/TextBlockEdit.jsx
+++ b/src/blocks/Text/TextBlockEdit.jsx
@@ -68,7 +68,7 @@ const TextBlockEdit = (props) => {
 
   const editorChange = (isVisible) => {
     isVisible && setIsEditorVisible(!isVisible);
-  }
+  };
 
   const prevReq = React.useRef(null);
 
@@ -197,37 +197,62 @@ const TextBlockEdit = (props) => {
       >
         {({ isVisible }) => {
           return (
-            <SlateEditor
-              index={index}
-              readOnly={selected ? isEditorVisible : true }
-              properties={properties}
-              extensions={textblockExtensions}
-              renderExtensions={[withBlockProperties]}
-              value={value}
-              block={block}
-              onFocus={() => onSelectBlock(block)}
-              onUpdate={handleUpdate}
-              debug={DEBUG}
-              onChange={(value, selection) => {
-                onChangeBlock(block, {
-                  ...data,
-                  value,
-                  plaintext: serializeNodesToText(value || []),
-                  // TODO: also add html serialized value
-                });
+            <Dropzone
+              disableClick
+              onDrop={onDrop}
+              className="dropzone"
+              onDragOver={() => setShowDropzone(true)}
+              onDragLeave={() => setShowDropzone(false)}
+            >
+              {({ getRootProps, getInputProps }) => {
+                return showDropzone ? (
+                  <div className="drop-indicator">
+                    {uploading ? (
+                      <Dimmer active>
+                        <Loader indeterminate>Uploading image</Loader>
+                      </Dimmer>
+                    ) : (
+                      <Message>
+                        <center>
+                          <img src={imageBlockSVG} alt="" />
+                        </center>
+                      </Message>
+                    )}
+                  </div>
+                ) : (
+                  <SlateEditor
+                    index={index}
+                    properties={properties}
+                    extensions={textblockExtensions}
+                    renderExtensions={[withBlockProperties]}
+                    value={value}
+                    block={block}
+                    onFocus={() => onSelectBlock(block)}
+                    onUpdate={handleUpdate}
+                    debug={DEBUG}
+                    onChange={(value, selection) => {
+                      onChangeBlock(block, {
+                        ...data,
+                        value,
+                        plaintext: serializeNodesToText(value || []),
+                        // TODO: also add html serialized value
+                      });
+                    }}
+                    onClick={(ev) => {
+                      // this is needed so that the click event does
+                      // not bubble up to the Blocks/Block/Edit.jsx component
+                      // which attempts to focus the TextBlockEdit on
+                      // click and this behavior breaks user selection, e.g.
+                      // when clicking once a selected word
+                      ev.stopPropagation();
+                    }}
+                    onKeyDown={handleKey}
+                    selected={selected}
+                    placeholder={placeholder}
+                  />
+                );
               }}
-              onClick={(ev) => {
-                // this is needed so that the click event does
-                // not bubble up to the Blocks/Block/Edit.jsx component
-                // which attempts to focus the TextBlockEdit on
-                // click and this behavior breaks user selection, e.g.
-                // when clicking once a selected word
-                ev.stopPropagation();
-              }}
-              onKeyDown={handleKey}
-              selected={selected}
-              placeholder={placeholder}
-            />
+            </Dropzone>
           );
         }}
       </VisibilitySensor>


### PR DESCRIPTION
The solution used is to simply reintroduce Dropzone and use it correctly (the inverse of this: https://github.com/eea/volto-slate/commit/9b2910d4c69f557fc880d066a7ed67f31d7cc2d6). This way these keys work well again:

* `Home`
* `End`
* `Shift+arrows`
* `Ctrl+A`
* maybe others too