### PR TITLE
Put SlateEditor above modal forms

### DIFF
--- a/src/editor/less/editor.less
+++ b/src/editor/less/editor.less
@@ -11,7 +11,7 @@
     position: absolute;
 
     /* should be above admin panes (100), and below the Link modal form (1000) */
-    z-index: 500;
+    z-index: 1500;
 
     top: -10000px;
     left: -10000px;


### PR DESCRIPTION
Other issues to solve in Volto Slate regarding Key Facts blocks:

- [ ] It seems to me that the floating toolbar, opened inside a modal form such as for Key Facts editing, does not disappear when the user clicks outside it or presses Escape or presses Tab. The same issue is when selecting the Link plugin's button and clicking in the newly opened sidebar to open the Object Browser.