### PR TITLE
Make slate_richtext widget backward compatible

### DIFF
--- a/src/widgets/RichTextWidget.jsx
+++ b/src/widgets/RichTextWidget.jsx
@@ -8,6 +8,7 @@ import { FormFieldWrapper } from '@plone/volto/components';
 import SlateEditor from 'volto-slate/editor/SlateEditor';
 
 import './style.css';
+import { createEmptyParagraph } from '../utils/blocks';
 
 const SlateRichTextWidget = (props) => {
   const {
@@ -45,7 +46,13 @@ const SlateRichTextWidget = (props) => {
           className={className}
           id={id}
           name={id}
-          value={value}
+          value={
+            typeof value === 'undefined' ||
+            typeof value.data !==
+              'undefined' /* previously this was a Draft block */
+              ? [createEmptyParagraph()]
+              : value
+          }
           onChange={(newValue) => {
             onChange(id, newValue);
           }}


### PR DESCRIPTION
with form fields that previously were Draft.js-based. This is dumb compatibility as it avoids the crash of Volto but shows the field as empty although there is a Draft.js value in it. Saving a new Slate value in this field works very well.