### PR TITLE
Make option if toolbar is floating or fixed on top of the block configurable

### DIFF
--- a/src/editor/SlateEditor.jsx
+++ b/src/editor/SlateEditor.jsx
@@ -64,7 +64,7 @@ class SlateEditor extends Component {
 
     this.state = {
       editor: this.createEditor(),
-      showExpandedToolbar: false,
+      showExpandedToolbar: config.settings.slate.showToolbar,
       hasDomSelection: false,
     };
 

--- a/src/editor/SlateEditor.jsx
+++ b/src/editor/SlateEditor.jsx
@@ -64,7 +64,7 @@ class SlateEditor extends Component {
 
     this.state = {
       editor: this.createEditor(),
-      showExpandedToolbar: config.settings.slate.showToolbar,
+      showExpandedToolbar: config.settings.slate.showExpandedToolbar,
       hasDomSelection: false,
     };
 

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -5,7 +5,7 @@ export SlateEditor from './SlateEditor';
 export default (config) => {
   config.settings.slate = {
     ...slateConfig,
-    showToolbar: false,
+    showExpandedToolbar: false,
   };
   config = installDefaultPlugins(config);
   return config;

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -5,6 +5,7 @@ export SlateEditor from './SlateEditor';
 export default (config) => {
   config.settings.slate = {
     ...slateConfig,
+    showToolbar: false,
   };
   config = installDefaultPlugins(config);
   return config;


### PR DESCRIPTION
- Make option if toolbar is floating or fixed on top of the block configurable
  TODO: Add some hint in docs that projects / add-ons can configure with 
  `config.settings.slate.showToolbar = true`;
- 