### PR TITLE
Pass metadata extras to Element in view mode

### DIFF
--- a/src/blocks/Text/TextBlockView.jsx
+++ b/src/blocks/Text/TextBlockView.jsx
@@ -4,18 +4,23 @@ import config from '@plone/volto/registry';
 const TextBlockView = (props) => {
   const { id, data, styling = {} } = props;
   const { value, override_toc } = data;
-  return serializeNodes(value, (node, path) => {
-    const res = { ...styling };
-    if (node.type) {
-      if (
-        config.settings.slate.topLevelTargetElements.includes(node.type) ||
-        override_toc
-      ) {
-        res.id = id;
+  const metadata = props.metadata || props.properties;
+  return serializeNodes(
+    value,
+    (node, path) => {
+      const res = { ...styling };
+      if (node.type) {
+        if (
+          config.settings.slate.topLevelTargetElements.includes(node.type) ||
+          override_toc
+        ) {
+          res.id = id;
+        }
       }
-    }
-    return res;
-  });
+      return res;
+    },
+    { metadata: metadata },
+  );
 };
 
 export default TextBlockView;

--- a/src/editor/render.jsx
+++ b/src/editor/render.jsx
@@ -21,7 +21,14 @@ export const Element = ({ element, attributes = {}, extras, ...rest }) => {
     ),
   );
 
-  return <El element={element} {...omit(rest, OMITTED)} attributes={out} />;
+  return (
+    <El
+      element={element}
+      {...omit(rest, OMITTED)}
+      attributes={out}
+      extras={extras}
+    />
+  );
 };
 
 export const Leaf = ({ children, ...rest }) => {
@@ -83,7 +90,7 @@ const serializeData = (node) => {
   return JSON.stringify({ type: node.type, data: node.data });
 };
 
-export const serializeNodes = (nodes, getAttributes) => {
+export const serializeNodes = (nodes, getAttributes, extras = {}) => {
   const editor = { children: nodes || [] };
 
   const _serializeNodes = (nodes) => {
@@ -106,6 +113,7 @@ export const serializeNodes = (nodes, getAttributes) => {
                 : null
               : null
           }
+          extras={extras}
         >
           {_serializeNodes(Array.from(Node.children(editor, path)))}
         </Element>


### PR DESCRIPTION
We need Form metadata for volto-slate-metadata-mentions to be passed in view mode (readOnly) to Elements