### PR TITLE
Better url deserialize

### DIFF
--- a/src/editor/extensions/insertData.js
+++ b/src/editor/extensions/insertData.js
@@ -50,11 +50,37 @@ export const insertData = (editor) => {
     'text/plain': (dt, fullMime) => {
       const text = dt;
       if (!text) return;
+
       const paras = text.split('\n');
       const fragment = paras.map((p) => createDefaultBlock([{ text: p }]));
       // return insertData(data);
 
+      // check if fragment is p with text and insert as fragment if so
+
+      const fragmentContainsText = (f) => {
+        var trigger = false;
+        if (f && f[0]) {
+          f.forEach((frag) => {
+            if (frag.type === 'p') {
+              if (frag.children) {
+                frag.children.forEach((child) => {
+                  if (child.text) {
+                    trigger = true;
+                  }
+                });
+              }
+            }
+          });
+        }
+        return trigger;
+      };
+
       // When there's already text in the editor, insert a fragment, not nodes
+      const containsText = fragmentContainsText(fragment);
+      if (fragment && containsText) {
+        Transforms.insertFragment(editor, fragment);
+      }
+
       if (Editor.string(editor, [])) {
         if (
           Array.isArray(fragment) &&
@@ -68,7 +94,9 @@ export const insertData = (editor) => {
       }
 
       const nodes = normalizeBlockNodes(editor, fragment);
-      Transforms.insertNodes(editor, nodes);
+      if (!containsText) {
+        Transforms.insertNodes(editor, nodes);
+      }
 
       return true;
     },

--- a/src/utils/volto-blocks.js
+++ b/src/utils/volto-blocks.js
@@ -138,29 +138,29 @@ export function getPreviousVoltoBlock(index, properties) {
   return [prevBlock, prevBlockId];
 }
 
-//check for existing img children
-const checkContainImg = (elements) => {
-  var check = false;
-  elements.forEach((e) =>
-    e.children.forEach((c) => {
-      if (c && c.type && c.type === 'img') {
-        check = true;
-      }
-    }),
-  );
-  return check;
-};
+// //check for existing img children
+// const checkContainImg = (elements) => {
+//   var check = false;
+//   elements.forEach((e) =>
+//     e.children.forEach((c) => {
+//       if (c && c.type && c.type === 'img') {
+//         check = true;
+//       }
+//     }),
+//   );
+//   return check;
+// };
 
-//check for existing table children
-const checkContainTable = (elements) => {
-  var check = false;
-  elements.forEach((e) => {
-    if (e && e.type && e.type === 'table') {
-      check = true;
-    }
-  });
-  return check;
-};
+// //check for existing table children
+// const checkContainTable = (elements) => {
+//   var check = false;
+//   elements.forEach((e) => {
+//     if (e && e.type && e.type === 'table') {
+//       check = true;
+//     }
+//   });
+//   return check;
+// };
 
 /**
  * The editor has the properties `dataTransferHandlers` (object) and
@@ -200,40 +200,10 @@ export function deconstructToVoltoBlocks(editor) {
   return new Promise((resolve, reject) => {
     if (!editor?.children) return;
 
-    var _editor = editor;
-    if (_editor.children.length === 1) {
+    if (editor.children.length === 1) {
       return resolve([blockProps.block]);
     }
-
-    // //catch for urls that will split the block.
-    // //This containsImage checks if the new top-level child contains an image
-    // var containsImage = checkContainImg(_editor.children);
-    // var containsTable = checkContainTable(_editor.children);
-    // //dont split into new blocks if it's an url. skip this if it has imgs
-    // if (_editor.children.length > 1 && !containsImage && !containsTable) {
-    //   var newChildren = [];
-    //   _editor.children.forEach((child) =>
-    //     child.children.forEach((nephew) => newChildren.push({ ...nephew })),
-    //   );
-    //   _editor = {
-    //     ...editor,
-    //     children: [
-    //       {
-    //         ...editor.children[0],
-    //         children:
-    //           editor.children.length > 1
-    //             ? newChildren
-    //             : [...editor.children[0].children],
-    //       },
-    //     ],
-    //   };
-    // }
-
-    const {
-      properties,
-      onChangeField,
-      onSelectBlock,
-    } = _editor.getBlockProps();
+    const { properties, onChangeField, onSelectBlock } = editor.getBlockProps();
     const blocksFieldname = getBlocksFieldname(properties);
     const blocksLayoutFieldname = getBlocksLayoutFieldname(properties);
 
@@ -241,20 +211,20 @@ export function deconstructToVoltoBlocks(editor) {
     let blocks = [];
 
     // TODO: should use Editor.levels() instead of Node.children
-    const pathRefs = Array.from(Node.children(_editor, [])).map(([, path]) =>
-      Editor.pathRef(_editor, path),
+    const pathRefs = Array.from(Node.children(editor, [])).map(([, path]) =>
+      Editor.pathRef(editor, path),
     );
 
     for (const pathRef of pathRefs) {
       // extra nodes are always extracted after the text node
       let extras = voltoBlockEmiters
-        .map((emit) => emit(_editor, pathRef))
+        .map((emit) => emit(editor, pathRef))
         .flat(1);
 
       // The node might have been replaced with a Volto block
       if (pathRef.current) {
-        const [childNode] = Editor.node(_editor, pathRef.current);
-        if (childNode && !Editor.isEmpty(_editor, childNode))
+        const [childNode] = Editor.node(editor, pathRef.current);
+        if (childNode && !Editor.isEmpty(editor, childNode))
           blocks.push(syncCreateSlateBlock([childNode]));
       }
       blocks = [...blocks, ...extras];

--- a/src/utils/volto-blocks.js
+++ b/src/utils/volto-blocks.js
@@ -205,29 +205,29 @@ export function deconstructToVoltoBlocks(editor) {
       return resolve([blockProps.block]);
     }
 
-    //catch for urls that will split the block.
-    //This containsImage checks if the new top-level child contains an image
-    var containsImage = checkContainImg(_editor.children);
-    var containsTable = checkContainTable(_editor.children);
-    //dont split into new blocks if it's an url. skip this if it has imgs
-    if (_editor.children.length > 1 && !containsImage && !containsTable) {
-      var newChildren = [];
-      _editor.children.forEach((child) =>
-        child.children.forEach((nephew) => newChildren.push({ ...nephew })),
-      );
-      _editor = {
-        ...editor,
-        children: [
-          {
-            ...editor.children[0],
-            children:
-              editor.children.length > 1
-                ? newChildren
-                : [...editor.children[0].children],
-          },
-        ],
-      };
-    }
+    // //catch for urls that will split the block.
+    // //This containsImage checks if the new top-level child contains an image
+    // var containsImage = checkContainImg(_editor.children);
+    // var containsTable = checkContainTable(_editor.children);
+    // //dont split into new blocks if it's an url. skip this if it has imgs
+    // if (_editor.children.length > 1 && !containsImage && !containsTable) {
+    //   var newChildren = [];
+    //   _editor.children.forEach((child) =>
+    //     child.children.forEach((nephew) => newChildren.push({ ...nephew })),
+    //   );
+    //   _editor = {
+    //     ...editor,
+    //     children: [
+    //       {
+    //         ...editor.children[0],
+    //         children:
+    //           editor.children.length > 1
+    //             ? newChildren
+    //             : [...editor.children[0].children],
+    //       },
+    //     ],
+    //   };
+    // }
 
     const {
       properties,


### PR DESCRIPTION
Changed the url deserialization from running the catch function in the deserializer to using insertData. 

This way insertData already recognizes the url pasted from browser as 'text/plain' and using slate Transforms.insertFragment to insert a fragment instead of making a new node. 