### PR TITLE
WIP on an uncommented Cypress test

### DIFF
--- a/cypress/integration/21-metadata-slate-format-link.js
+++ b/cypress/integration/21-metadata-slate-format-link.js
@@ -43,54 +43,52 @@ describe('RichText Tests: Add links', () => {
     cy.get('[id="view"] p a').contains('green ideas sleep');
   });
 
-  // TODO: Fix and enable multiple links links
+  it.only('As editor I can add multiple lines and add links', function () {
+    // Complete chained commands
+    cy.getSlateEditorAndType(
+      'Colorless green ideas{enter}{enter}sleep furiously.',
+    );
 
-  // it('As editor I can add multiple lines and add links', function () {
-  //   // Complete chained commands
-  //   cy.getSlateEditorAndType(
-  //     'Colorless green ideas{enter}{enter}sleep furiously.',
-  //   );
+    // Link
+    cy.setSlateSelection('green', 'furiously');
+    cy.clickSlateButton('Link');
 
-  //   // Link
-  //   cy.setSlateSelection('green', 'furiously');
-  //   cy.clickSlateButton('Link');
+    cy.get('.sidebar-container a.item:nth-child(3)').click();
+    cy.get('input[name="external_link-0-external"]')
+      .click()
+      .type('https://example.com{enter}');
+    cy.get('.sidebar-container .form .header button:first-of-type').click();
 
-  //   cy.get('.sidebar-container a.item:nth-child(3)').click();
-  //   cy.get('input[name="external_link-0-external"]')
-  //     .click()
-  //     .type('https://example.com{enter}');
-  //   cy.get('.sidebar-container .form .header button:first-of-type').click();
+    // Remove link
+    cy.setSlateSelection('ideas');
+    cy.clickSlateButton('Remove link');
 
-  //   // Remove link
-  //   cy.setSlateSelection('ideas');
-  //   cy.clickSlateButton('Remove link');
+    cy.setSlateSelection('sleep');
+    cy.clickSlateButton('Remove link');
 
-  //   cy.setSlateSelection('sleep');
-  //   cy.clickSlateButton('Remove link');
+    // Re-add link
+    cy.setSlateSelection('Colorless', 'furiously');
+    cy.clickSlateButton('Link');
 
-  //   // Re-add link
-  //   cy.setSlateSelection('Colorless', 'furiously');
-  //   cy.clickSlateButton('Link');
+    cy.get('.sidebar-container a.item:nth-child(3)').click();
+    cy.get('input[name="external_link-0-external"]')
+      .click()
+      .type('https://google.com{enter}');
+    cy.get('.sidebar-container .form .header button:first-of-type').click();
 
-  //   cy.get('.sidebar-container a.item:nth-child(3)').click();
-  //   cy.get('input[name="external_link-0-external"]')
-  //     .click()
-  //     .type('https://google.com{enter}');
-  //   cy.get('.sidebar-container .form .header button:first-of-type').click();
+    // Save
+    cy.toolbarSave();
 
-  //   // Save
-  //   cy.toolbarSave();
-
-  //   // then the page view should contain a link
-  //   cy.get('.slate.widget p:first-of-type a')
-  //     .should('have.attr', 'href')
-  //     .and('include', 'https://google.com');
-  //   cy.get('.slate.widget p:first-of-type a').contains('Colorless green ideas');
-  //   cy.get('.slate-widget p:last-of-type a')
-  //     .should('have.attr', 'href')
-  //     .and('include', 'https://google.com');
-  //   cy.get('.slate-widget p:last-of-type a').contains('sleep furiously.');
-  // });
+    // then the page view should contain a link
+    cy.get('#view p:first-of-type a')
+      .should('have.attr', 'href')
+      .and('include', 'https://google.com');
+    cy.get('#view p:first-of-type a').contains('Colorless green ideas');
+    cy.get('#view p:last-of-type a')
+      .should('have.attr', 'href')
+      .and('include', 'https://google.com');
+    cy.get('#view p:last-of-type a').contains('sleep furiously.');
+  });
 
   // it('As editor I can select multiple paragraphs and add links', function () {
   //   // Complete chained commands

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -345,7 +345,9 @@ Cypress.Commands.add('waitForResourceToLoad', (fileName, type) => {
 Cypress.Commands.add('selection', { prevSubject: true }, (subject, fn) => {
   cy.wrap(subject).trigger('mousedown').then(fn).trigger('mouseup');
 
+  // TODO: this does not work sometimes
   cy.document().trigger('selectionchange');
+
   return cy.wrap(subject);
 });
 

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
     "is-url": "1.2.4",
     "jsdom": "16.2.2",
     "react-visibility-sensor": "5.1.1",
-    "slate": "^0.62.0",
-    "slate-history": "^0.62.0",
-    "slate-hyperscript": "^0.62.0",
-    "slate-react": "^0.62.0",
+    "slate": "^0.66.5",
+    "slate-history": "^0.66.0",
+    "slate-hyperscript": "^0.66.0",
+    "slate-react": "^0.66.4",
     "weak-key": "^1.0.2"
   },
   "peerDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -103,7 +103,7 @@ export function asDefault(config) {
   asDefaultBlock(config);
 
   // TODO: See cypress
-  // asDefaultRichText(config);
+  asDefaultRichText(config);
 
   return config;
 }

--- a/src/utils/blocks.js
+++ b/src/utils/blocks.js
@@ -104,10 +104,10 @@ const normalizeToSlateConstraints = (editor, nodes) => {
           return isFirstInline
             ? [{ text: '' }, node]
             : isLastInline
-            ? [...acc, node, { text: '' }]
-            : isBetweenInlines
-            ? [...acc, { text: '' }, node]
-            : [...acc, node];
+              ? [...acc, node, { text: '' }]
+              : isBetweenInlines
+                ? [...acc, { text: '' }, node]
+                : [...acc, node];
         }, []),
       );
     }
@@ -142,6 +142,36 @@ export function normalizeBlockNodes(editor, children) {
 
   nodes = normalizeToSlateConstraints(editor, nodes);
   return nodes;
+}
+
+/**
+ * Partially normalizes nodes of type 'a' which are inline (adds an empty Text
+ * inside them if empty) and puts an empty Text after the last 'a' inside a
+ * block. This function is recursive.
+ * 
+ * In future it might be useful to create a more general normalizeInlineNodes
+ * function or even use Editor.normalize feature of Slate Editor interface after
+ * putting the `children` inside an `editor`.
+ */
+export function normalizeLinkNodes(editor, children) {
+  let lastType = null;
+
+  for (let c of children) {
+    lastType = c.type;
+    if (c.type === 'a') {
+      if (c.children.length === 0) {
+        c.children.push({ text: '' });
+      }
+    } else if (c.children) {
+      normalizeLinkNodes(editor, c.children);
+    }
+  }
+
+  if (lastType === 'a') {
+    children.push({ text: '' });
+  }
+
+  return children;
 }
 
 export function createDefaultBlock(children) {

--- a/src/widgets/HtmlSlateWidget.jsx
+++ b/src/widgets/HtmlSlateWidget.jsx
@@ -15,7 +15,11 @@ import { serializeNodes } from 'volto-slate/editor/render';
 import makeEditor from 'volto-slate/editor/makeEditor';
 import deserialize from 'volto-slate/editor/deserialize';
 
-import { createEmptyParagraph, normalizeBlockNodes } from 'volto-slate/utils';
+import {
+  createEmptyParagraph,
+  normalizeBlockNodes,
+  normalizeLinkNodes,
+} from 'volto-slate/utils';
 import { ErrorBoundary } from './ErrorBoundary';
 
 import './style.css';
@@ -80,6 +84,8 @@ const HtmlSlateWidget = (props) => {
       let data = deserialize(editor, body);
       data = normalizeBlockNodes(editor, data);
 
+      data = normalizeLinkNodes(editor, data);
+
       // editor.children = data;
       // Editor.normalize(editor);
       // TODO: need to add {text: ""} placeholders between elements
@@ -100,7 +106,7 @@ const HtmlSlateWidget = (props) => {
         onClick={() => {
           setSelected(true);
         }}
-        onKeyDown={() => {}}
+        onKeyDown={() => { }}
       >
         <ErrorBoundary name={intl.formatMessage(messages.error, { name: id })}>
           <SlateEditor


### PR DESCRIPTION
- Upgrade Slate-related dependencies
- New TODO comment
- Enable Slate as default rich text editor
- Improve normalization in `HtmlSlateWidget`
- Improve code formatting

Temporarily marked the Cypress test as `only` for easier debugging.